### PR TITLE
fix: ensure record names include the domain name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/leaseweb
 
-go 1.16
+go 1.22
 
 require github.com/libdns/libdns v0.2.0

--- a/helpers.go
+++ b/helpers.go
@@ -41,6 +41,13 @@ func fromLibdns(zone string, records []libdns.Record) ([]leasewebRecordSet, erro
 
 		// Cleanup record name and ensure it ends with domain.ext[dot] even if dns_challenge_override_domain is set
 		// trimming both zone & domainName is probably overzealous, but better be safe then sorry
+		// Example:
+		//   zone: example.com.
+		//   domainName: example.com
+		//   dnsRecord.Name 1: _acme-challenge.example.com
+		//   dnsRecord.Name 2: _acme-challenge.example.com.
+		//   dnsRecord.Name 3: _acme-challenge.
+		//   all after cleanup -> _acme-challenge.example.com.
 		var recordName = fmt.Sprintf("%s.%s", strings.TrimSuffix(strings.TrimSuffix(currentRecordInfo.libdnsRecord.Name, zone), domainName), zone)
 		var recordTTL = int(currentRecordInfo.libdnsRecord.TTL.Seconds())
 		if !slices.Contains(supportedTTLs, recordTTL) {

--- a/helpers.go
+++ b/helpers.go
@@ -53,6 +53,8 @@ func fromLibdns(zone string, records []libdns.Record) ([]leasewebRecordSet, erro
 		if !slices.Contains(supportedTTLs, recordTTL) {
 			// Use the first listed TTL if the user did not provide a TTL or provided a unsupported value
 			// It would probably be nice to log a warning about this, but that doesn't seem to be supported in libdns
+			// Note: Leaseweb uses a default value of 3600. But as this lib will probably mostly be used
+			// with caddy-dns/leaseweb to solve ACME DNS-01 challenges, let's use the lowest possible value
 			recordTTL = supportedTTLs[0]
 		}
 

--- a/provider.go
+++ b/provider.go
@@ -145,7 +145,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		err = handleLeasewebHttpError(res)
+		err = handleLeasewebHttpError(res, "delete")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
chore: improve error logging

Creating leaseweb dns records was broken, most likely since 16f977f89705fd828c1159e190e33f959760a416 as the fix that was added in 5c5257eb2569593ee6abb0c156b6a9fe92a1c7f5 to append the domain name after the record name was remove in the former commit (by accident I guess?)

Also improved error logging a bit as it was quite difficult at first to understand from the logs what was happening. Now the full error from leaseweb is included in the error message, so f.e. also the specific field errors.